### PR TITLE
Merge 5.4.3-rc2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -422,7 +422,6 @@ jobs:
 
     - name: Build sdist using publishing workflow
       run: |
-        . /opt/rh/devtoolset-7/enable
         cp packaging/wheel/* .
         ./publish.sh
         ls -lhtra dist/
@@ -559,6 +558,7 @@ jobs:
         yum update -y
         yum install --nogpg -y \
             cmake3 \
+            gcc-c++ \
             make \
             krb5-devel \
             libuuid-devel \
@@ -580,7 +580,6 @@ jobs:
 
     - name: Build sdist using publishing workflow
       run: |
-        . /opt/rh/devtoolset-7/enable
         cp packaging/wheel/* .
         ./publish.sh
         cd ..  # Move xrootd.egg-info off PYTHONPATH
@@ -606,6 +605,7 @@ jobs:
         yum update -y
         yum install --nogpg -y \
             cmake3 \
+            gcc-c++ \
             make \
             krb5-devel \
             libuuid-devel \
@@ -627,7 +627,6 @@ jobs:
 
     - name: Build sdist using publishing workflow
       run: |
-        . /opt/rh/devtoolset-7/enable
         cp packaging/wheel/* .
         ./publish.sh
         cd ..  # Move xrootd.egg-info off PYTHONPATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -582,8 +582,7 @@ jobs:
       run: |
         cp packaging/wheel/* .
         ./publish.sh
-        cd ..  # Move xrootd.egg-info off PYTHONPATH
-        python3 -m pip --verbose install xrootd/dist/xrootd-*.tar.gz
+        python3 -m pip --verbose install --upgrade ./dist/xrootd-*.tar.gz
         python3 -m pip list
 
     - name: Verify Python bindings
@@ -629,8 +628,7 @@ jobs:
       run: |
         cp packaging/wheel/* .
         ./publish.sh
-        cd ..  # Move xrootd.egg-info off PYTHONPATH
-        python3 -m pip --verbose install xrootd/dist/xrootd-*.tar.gz
+        python3 -m pip --verbose install --upgrade ./dist/xrootd-*.tar.gz
         python3 -m pip list
 
     - name: Verify Python bindings
@@ -677,7 +675,7 @@ jobs:
       run: |
         cp packaging/wheel/* .
         ./publish.sh
-        python3 -m pip --verbose install ./dist/xrootd-*.tar.gz
+        python3 -m pip --verbose install --upgrade ./dist/xrootd-*.tar.gz
         python3 -m pip list
 
     - name: Show site-pacakges layout for XRootD modules

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,7 @@ jobs:
 
     - name: Verify Python bindings
       run: |
+        python3 --version --version
         python3 -m pip list
         python3 -m pip show xrootd
         python3 -c 'import XRootD; print(XRootD)'
@@ -154,6 +155,7 @@ jobs:
 
     - name: Verify Python bindings
       run: |
+        python3 --version --version
         python3 -m pip list
         python3 -m pip show xrootd
         python3 -c 'import XRootD; print(XRootD)'
@@ -221,6 +223,7 @@ jobs:
 
     - name: Verify Python bindings
       run: |
+        python2 --version
         python2 -m pip list
         python2 -m pip show xrootd
         python2 -c 'import XRootD; print(XRootD)'
@@ -284,6 +287,7 @@ jobs:
         export LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
         export PYTHON_VERSION_MINOR=$(python3 -c 'import sys; print(f"{sys.version_info.minor}")')
         export PYTHONPATH="/usr/local/lib/python3.${PYTHON_VERSION_MINOR}/site-packages:${PYTHONPATH}"
+        python3 --version --version
         python3 -m pip list
         python3 -m pip show xrootd
         python3 -c 'import XRootD; print(XRootD)'
@@ -347,6 +351,7 @@ jobs:
 
     - name: Verify Python bindings
       run: |
+        python3 --version --version
         python3 -m pip list
         python3 -m pip show xrootd
         python3 -c 'import XRootD; print(XRootD)'
@@ -414,6 +419,7 @@ jobs:
 
     - name: Verify Python bindings
       run: |
+        python3 --version --version
         python3 -m pip list
         python3 -m pip show xrootd
         python3 -c 'import XRootD; print(XRootD)'
@@ -477,6 +483,7 @@ jobs:
 
     - name: Verify Python bindings
       run: |
+        python3 --version --version
         python3 -m pip list
         python3 -m pip show xrootd
         python3 -c 'import XRootD; print(XRootD)'
@@ -541,6 +548,7 @@ jobs:
 
     - name: Verify Python bindings
       run: |
+        python3 --version --version
         python3 -m pip list
         python3 -m pip show xrootd
         python3 -c 'import XRootD; print(XRootD)'
@@ -570,6 +578,7 @@ jobs:
             python3-devel \
             python3-setuptools \
             git \
+            tree \
             cppunit-devel
         yum clean all
         python3 -m pip --no-cache-dir install wheel
@@ -585,8 +594,15 @@ jobs:
         python3 -m pip --verbose install --upgrade ./dist/xrootd-*.tar.gz
         python3 -m pip list
 
+    - name: Show site-pacakges layout for XRootD modules
+      run: |
+        find $(python3 -c 'import XRootD; import pathlib; print(str(pathlib.Path(XRootD.__path__[0]).parent))') \
+          -type d \
+          -iname "*xrootd*" | xargs tree
+
     - name: Verify Python bindings
       run: |
+        python3 --version --version
         python3 -m pip list
         python3 -m pip show xrootd
         python3 -c 'import XRootD; print(XRootD)'
@@ -616,6 +632,7 @@ jobs:
             python3-devel \
             python3-setuptools \
             git \
+            tree \
             cppunit-devel
         yum clean all
         python3 -m pip --no-cache-dir install --upgrade pip setuptools wheel
@@ -631,8 +648,15 @@ jobs:
         python3 -m pip --verbose install --upgrade ./dist/xrootd-*.tar.gz
         python3 -m pip list
 
+    - name: Show site-pacakges layout for XRootD modules
+      run: |
+        find $(python3 -c 'import XRootD; import pathlib; print(str(pathlib.Path(XRootD.__path__[0]).parent))') \
+          -type d \
+          -iname "*xrootd*" | xargs tree
+
     - name: Verify Python bindings
       run: |
+        python3 --version --version
         python3 -m pip list
         python3 -m pip show xrootd
         python3 -c 'import XRootD; print(XRootD)'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -456,6 +456,8 @@ jobs:
 
     - name: Build
       run: |
+        # c.f. https://github.com/actions/checkout/issues/760
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
         cd packaging/
         ./makesrpm.sh \
           --define "_with_python3 1" \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -153,7 +153,7 @@ build:cc7:
 #    - schedules
 #    - web
 
-build:fedorai-35:
+build:fedora-35:
   stage: build:rpm
   image: fedora:35
   script:

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -83,7 +83,7 @@ if ( NOT ${VALID_PIP_EXIT_CODE} EQUAL 0 )
   install(
     CODE
     "EXECUTE_PROCESS(
-      COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY} install \
+      COMMAND /usr/bin/env ${XROOTD_PYBUILD_ENV} ${PYTHON_EXECUTABLE} ${SETUP_PY} install \
                 --verbose \
                 --prefix \$ENV{DESTDIR}/${CMAKE_INSTALL_PREFIX} \
                 ${DEB_INSTALL_ARGS}
@@ -94,7 +94,7 @@ else()
   install(
     CODE
     "EXECUTE_PROCESS(
-      COMMAND ${PYTHON_EXECUTABLE} -m pip install \
+      COMMAND /usr/bin/env ${XROOTD_PYBUILD_ENV} ${PYTHON_EXECUTABLE} -m pip install \
                 ${PIP_OPTIONS} \
                 ${CMAKE_CURRENT_BINARY_DIR}
       )"

--- a/bindings/python/setup.py.in
+++ b/bindings/python/setup.py.in
@@ -1,7 +1,23 @@
 from __future__ import print_function
 
-from distutils.core import setup, Extension
-from distutils import sysconfig
+# setuptools._distutils added in setuptools v48.0.0
+# c.f. https://setuptools.pypa.io/en/latest/history.html#v48-0-0
+try:
+    from setuptools._distutils.core import setup, Extension
+    # sysconfig v48.0.0+ is incompatible for Python 3.6 only, so fall back to distutils.
+    # Instead of checking setuptools.__version__ explicitly, use the knowledge that
+    # to get here in the 'try' block requires setuptools v48.0.0+.
+    # FIXME: When support for Python 3.6 is dropped simplify this
+    import sys
+
+    if sys.version_info < (3, 7):
+        from distutils import sysconfig
+    else:
+        import sysconfig
+except ImportError:
+    from distutils.core import setup, Extension
+    from distutils import sysconfig
+
 from os import getenv, walk, path
 import subprocess
 

--- a/docs/ReleaseNotes.txt
+++ b/docs/ReleaseNotes.txt
@@ -44,6 +44,8 @@ Version 5.4.3
   **[PIP]** Add PIP_OPTIONS CMake option for greater control of Python bindings
             install.
   **[Python]** Remove unused Python setup files from old workflows.
+  **[Python]** Provide cmake switch (XROOTD_PYBUILD_ENV) for setting up python
+               build environment.
   **[XrdSys]** Don't abort if it looks like we're about to fork.
   **[Utils]** Avoid emitting fatal polling error message unless aborting.
   **[Server]** Avoid misleading error message due to queued but delayed event.

--- a/docs/ReleaseNotes.txt
+++ b/docs/ReleaseNotes.txt
@@ -18,6 +18,7 @@ Version 5.4.3
   **[XrdCl]** Fix VectorRead raw data socket readout.
   **[XrdCrypto]** OpenSSL3: correctly initialize cipher with public key and DH
                   parameters, fixes #1662
+  **[XrdCrypto]** bf32: respect the key length when encrypting/decrypting.
   **[XrdAcc]** Make the acc subsystem aware of request-based name mapping.
   **[XrdTpc]** [XrdTpc] Added CLOEXEC flag for curl file descriptors.
   **[XProtocol]** Make sure ECANCELED is translated to kXR_Cancelled.

--- a/packaging/rhel/xrootd.spec.in
+++ b/packaging/rhel/xrootd.spec.in
@@ -112,6 +112,7 @@ BuildRequires: python2-devel
 BuildRequires: python2-setuptools
 %endif
 %if %{python2and3}
+BuildRequires: python2-pip
 BuildRequires: python2-devel
 BuildRequires: python2-setuptools
 BuildRequires: python%{python3_pkgversion}-devel

--- a/src/XrdCrypto/XrdCryptoLite_bf32.cc
+++ b/src/XrdCrypto/XrdCryptoLite_bf32.cc
@@ -94,7 +94,10 @@ int XrdCryptoLite_bf32::Decrypt(const char *key,
 // Decrypt
 //
    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
-   EVP_DecryptInit_ex(ctx, EVP_bf_cfb64(), 0, (unsigned char *)key, ivec);
+   EVP_DecryptInit_ex(ctx, EVP_bf_cfb64(), NULL, NULL, NULL);
+   EVP_CIPHER_CTX_set_padding(ctx, 0);
+   EVP_CIPHER_CTX_set_key_length(ctx, keyLen);
+   EVP_DecryptInit_ex(ctx, NULL, NULL, (unsigned char *)key, ivec);
    EVP_DecryptUpdate(ctx, (unsigned char *)dst, &wLen,
                           (unsigned char *)src, srcLen);
    EVP_DecryptFinal_ex(ctx, (unsigned char *)dst, &wLen);
@@ -149,7 +152,10 @@ int XrdCryptoLite_bf32::Encrypt(const char *key,
 // Encrypt
 //
    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
-   EVP_EncryptInit_ex(ctx, EVP_bf_cfb64(), 0, (unsigned char *)key, ivec);
+   EVP_EncryptInit_ex(ctx, EVP_bf_cfb64(), NULL, NULL, NULL);
+   EVP_CIPHER_CTX_set_padding(ctx, 0);
+   EVP_CIPHER_CTX_set_key_length(ctx, keyLen);
+   EVP_EncryptInit_ex(ctx, NULL, NULL, (unsigned char *)key, ivec);
    EVP_EncryptUpdate(ctx, (unsigned char *)dst, &wLen, bP, dLen);
    EVP_EncryptFinal_ex(ctx, (unsigned char *)dst, &wLen);
    EVP_CIPHER_CTX_free(ctx);


### PR DESCRIPTION
- [Python] Provide cmake switch (XROOTD_PYBUILD_ENV) for setting up python build environment.
- [Docs] Update release notes for 5.4.3.
- [CI] Remove unnecessary source of devtoolset-7
- [CI] Use --upgrade to avoid changing directories for install of sdist
- [CI] Improve logging information in GHA workflows
- [Python] Deprecate distutils for setuptools when possible
- [RPM] Add python2-pip to BuildRequires
- [CI] Avoid unsafe repository error from GitHub Actions
- [CI] Fix typo in build name for consistency
- [XrdCrypto] bf32: respect the key length when encrypting/decrypting.
- [Docs] Update release notes for 5.4.3.
